### PR TITLE
security: migrate iOS secrets from UserDefaults to Keychain

### DIFF
--- a/samples/CameraAccess/CameraAccess.xcodeproj/project.pbxproj
+++ b/samples/CameraAccess/CameraAccess.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		9DD6CB0E2F3C64F400ED7098 /* WebRTCOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DD6CB0D2F3C64F400ED7098 /* WebRTCOverlayView.swift */; };
 		9DD894B22F4047630090B9B9 /* SettingsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DD894AF2F4047630090B9B9 /* SettingsManager.swift */; };
 		9DD894B32F4047630090B9B9 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DD894B02F4047630090B9B9 /* SettingsView.swift */; };
+		9DD894B52F4047630090B9B9 /* KeychainManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DD894B42F4047630090B9B9 /* KeychainManager.swift */; };
 		9DD895962F405E0E0090B9B9 /* RTCVideoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DD895952F405E0E0090B9B9 /* RTCVideoView.swift */; };
 		9DD895972F405E0E0090B9B9 /* PiPVideoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DD895942F405E0E0090B9B9 /* PiPVideoView.swift */; };
 		A1B2C3D42F0A000200000001 /* GeminiConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42F0A000100000001 /* GeminiConfig.swift */; };
@@ -108,6 +109,7 @@
 		9DD6CB0D2F3C64F400ED7098 /* WebRTCOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebRTCOverlayView.swift; sourceTree = "<group>"; };
 		9DD894AF2F4047630090B9B9 /* SettingsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsManager.swift; sourceTree = "<group>"; };
 		9DD894B02F4047630090B9B9 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
+		9DD894B42F4047630090B9B9 /* KeychainManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainManager.swift; sourceTree = "<group>"; };
 		9DD895942F405E0E0090B9B9 /* PiPVideoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PiPVideoView.swift; sourceTree = "<group>"; };
 		9DD895952F405E0E0090B9B9 /* RTCVideoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RTCVideoView.swift; sourceTree = "<group>"; };
 		A1B2C3D42F0A000100000001 /* GeminiConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeminiConfig.swift; sourceTree = "<group>"; };
@@ -261,6 +263,7 @@
 			isa = PBXGroup;
 			children = (
 				9DD894AF2F4047630090B9B9 /* SettingsManager.swift */,
+				9DD894B42F4047630090B9B9 /* KeychainManager.swift */,
 				9DD894B02F4047630090B9B9 /* SettingsView.swift */,
 			);
 			path = Settings;
@@ -435,6 +438,7 @@
 				A1B2C3D42F0A000200000003 /* AudioManager.swift in Sources */,
 				A1B2C3D42F0A000200000004 /* GeminiSessionViewModel.swift in Sources */,
 				9DD894B22F4047630090B9B9 /* SettingsManager.swift in Sources */,
+				9DD894B52F4047630090B9B9 /* KeychainManager.swift in Sources */,
 				9DD894B32F4047630090B9B9 /* SettingsView.swift in Sources */,
 				A1B2C3D42F0A000200000005 /* GeminiOverlayView.swift in Sources */,
 			);

--- a/samples/CameraAccess/CameraAccess/Settings/KeychainManager.swift
+++ b/samples/CameraAccess/CameraAccess/Settings/KeychainManager.swift
@@ -1,0 +1,59 @@
+import Foundation
+import Security
+
+/// Thin wrapper around the iOS Keychain for storing sensitive strings (API keys, tokens).
+/// Replaces UserDefaults for secret storage — UserDefaults is unencrypted and readable
+/// from device backups.
+enum KeychainManager {
+  private static let service = "com.visionclaw.secrets"
+
+  static func get(_ key: String) -> String? {
+    let query: [String: Any] = [
+      kSecClass as String: kSecClassGenericPassword,
+      kSecAttrService as String: service,
+      kSecAttrAccount as String: key,
+      kSecReturnData as String: true,
+      kSecMatchLimit as String: kSecMatchLimitOne
+    ]
+    var item: CFTypeRef?
+    let status = SecItemCopyMatching(query as CFDictionary, &item)
+    guard status == errSecSuccess, let data = item as? Data else { return nil }
+    return String(data: data, encoding: .utf8)
+  }
+
+  static func set(_ key: String, value: String) {
+    let data = Data(value.utf8)
+
+    // Try update first (cheaper than delete+add)
+    let query: [String: Any] = [
+      kSecClass as String: kSecClassGenericPassword,
+      kSecAttrService as String: service,
+      kSecAttrAccount as String: key
+    ]
+    let update: [String: Any] = [kSecValueData as String: data]
+    let updateStatus = SecItemUpdate(query as CFDictionary, update as CFDictionary)
+
+    if updateStatus == errSecItemNotFound {
+      var addQuery = query
+      addQuery[kSecValueData as String] = data
+      SecItemAdd(addQuery as CFDictionary, nil)
+    }
+  }
+
+  static func delete(_ key: String) {
+    let query: [String: Any] = [
+      kSecClass as String: kSecClassGenericPassword,
+      kSecAttrService as String: service,
+      kSecAttrAccount as String: key
+    ]
+    SecItemDelete(query as CFDictionary)
+  }
+
+  static func deleteAll() {
+    let query: [String: Any] = [
+      kSecClass as String: kSecClassGenericPassword,
+      kSecAttrService as String: service
+    ]
+    SecItemDelete(query as CFDictionary)
+  }
+}

--- a/samples/CameraAccess/CameraAccess/Settings/SettingsManager.swift
+++ b/samples/CameraAccess/CameraAccess/Settings/SettingsManager.swift
@@ -5,12 +5,17 @@ final class SettingsManager {
 
   private let defaults = UserDefaults.standard
 
-  private enum Key: String {
+  // Keys for secrets (stored in Keychain)
+  private enum SecretKey: String {
     case geminiAPIKey
-    case openClawHost
-    case openClawPort
     case openClawHookToken
     case openClawGatewayToken
+  }
+
+  // Keys for non-sensitive settings (stored in UserDefaults)
+  private enum Key: String {
+    case openClawHost
+    case openClawPort
     case geminiSystemPrompt
     case webrtcSignalingURL
     case speakerOutputEnabled
@@ -18,13 +23,32 @@ final class SettingsManager {
     case proactiveNotificationsEnabled
   }
 
-  private init() {}
+  private init() {
+    migrateSecretsFromUserDefaults()
+  }
 
-  // MARK: - Gemini
+  /// One-time migration: move secrets from UserDefaults to Keychain.
+  /// Runs on first launch after update — old UserDefaults entries are deleted.
+  private func migrateSecretsFromUserDefaults() {
+    let migrationKey = "secrets_migrated_to_keychain"
+    guard !defaults.bool(forKey: migrationKey) else { return }
+
+    for key in [SecretKey.geminiAPIKey, .openClawHookToken, .openClawGatewayToken] {
+      if let value = defaults.string(forKey: key.rawValue), !value.isEmpty {
+        KeychainManager.set(key.rawValue, value: value)
+        defaults.removeObject(forKey: key.rawValue)
+        NSLog("[Settings] Migrated %@ from UserDefaults to Keychain", key.rawValue)
+      }
+    }
+
+    defaults.set(true, forKey: migrationKey)
+  }
+
+  // MARK: - Gemini (secrets in Keychain)
 
   var geminiAPIKey: String {
-    get { defaults.string(forKey: Key.geminiAPIKey.rawValue) ?? Secrets.geminiAPIKey }
-    set { defaults.set(newValue, forKey: Key.geminiAPIKey.rawValue) }
+    get { KeychainManager.get(SecretKey.geminiAPIKey.rawValue) ?? Secrets.geminiAPIKey }
+    set { KeychainManager.set(SecretKey.geminiAPIKey.rawValue, value: newValue) }
   }
 
   var geminiSystemPrompt: String {
@@ -48,13 +72,13 @@ final class SettingsManager {
   }
 
   var openClawHookToken: String {
-    get { defaults.string(forKey: Key.openClawHookToken.rawValue) ?? Secrets.openClawHookToken }
-    set { defaults.set(newValue, forKey: Key.openClawHookToken.rawValue) }
+    get { KeychainManager.get(SecretKey.openClawHookToken.rawValue) ?? Secrets.openClawHookToken }
+    set { KeychainManager.set(SecretKey.openClawHookToken.rawValue, value: newValue) }
   }
 
   var openClawGatewayToken: String {
-    get { defaults.string(forKey: Key.openClawGatewayToken.rawValue) ?? Secrets.openClawGatewayToken }
-    set { defaults.set(newValue, forKey: Key.openClawGatewayToken.rawValue) }
+    get { KeychainManager.get(SecretKey.openClawGatewayToken.rawValue) ?? Secrets.openClawGatewayToken }
+    set { KeychainManager.set(SecretKey.openClawGatewayToken.rawValue, value: newValue) }
   }
 
   // MARK: - WebRTC
@@ -88,9 +112,9 @@ final class SettingsManager {
   // MARK: - Reset
 
   func resetAll() {
-    for key in [Key.geminiAPIKey, .geminiSystemPrompt, .openClawHost, .openClawPort,
-                .openClawHookToken, .openClawGatewayToken, .webrtcSignalingURL,
-                .speakerOutputEnabled, .videoStreamingEnabled,
+    KeychainManager.deleteAll()
+    for key in [Key.geminiSystemPrompt, .openClawHost, .openClawPort,
+                .webrtcSignalingURL, .speakerOutputEnabled, .videoStreamingEnabled,
                 .proactiveNotificationsEnabled] {
       defaults.removeObject(forKey: key.rawValue)
     }


### PR DESCRIPTION
## Problem

API keys and tokens (Gemini API key, OpenClaw gateway token, hook token) are stored in `UserDefaults`, which is:
- **Unencrypted** on disk
- **Readable** from device backups (iTunes/Finder)
- **Accessible** to other apps on jailbroken devices

This was flagged in **Issue #1** (API key leaking) and is also relevant to **PR #8** (in-app secrets management).

## Fix

### New: `KeychainManager.swift`
Thin wrapper around `Security.framework` — 59 lines, zero dependencies:
- `get(_:)` / `set(_:value:)` / `delete(_:)` / `deleteAll()`
- Uses `kSecClassGenericPassword` with a service identifier
- Update-first strategy (cheaper than delete+add)

### Changed: `SettingsManager.swift`
- **Secrets** (API keys, tokens) → **Keychain** (encrypted, hardware-backed)
- **Settings** (host, port, toggles) → **UserDefaults** (unchanged, non-sensitive)
- **Auto-migration**: on first launch after update, moves existing UserDefaults secrets to Keychain and deletes the old entries

## Migration Behavior

| Existing user | What happens |
|---------------|-------------|
| Has secrets in UserDefaults | Auto-migrated to Keychain on first launch, then deleted from UserDefaults |
| New install | Secrets go directly to Keychain |
| Reset all settings | Both Keychain and UserDefaults are cleared |

## Files Changed
- `Settings/KeychainManager.swift` (new)
- `Settings/SettingsManager.swift` (modified)

## Test plan
- [ ] Fresh install: enter API key in Settings → verify it persists across app restarts
- [ ] Existing install: verify secrets auto-migrate (check "Migrated ... to Keychain" in logs)
- [ ] Reset all settings → verify API key is cleared
- [ ] Verify UserDefaults plist no longer contains API keys (inspect with `plutil`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)