### PR TITLE
fix: Android security hardening + resource leak fixes

### DIFF
--- a/samples/CameraAccessAndroid/app/src/main/AndroidManifest.xml
+++ b/samples/CameraAccessAndroid/app/src/main/AndroidManifest.xml
@@ -19,7 +19,7 @@
         android:icon="@mipmap/ic_launcher"
         android:label="VisionClaw"
         android:supportsRtl="true"
-        android:usesCleartextTraffic="true"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:theme="@style/Theme.CameraAccess">
 
         <!-- Without Developer Mode, this key will need to be set with ID from app registered in Wearables Developer Center -->

--- a/samples/CameraAccessAndroid/app/src/main/java/com/meta/wearable/dat/externalsampleapps/cameraaccess/gemini/GeminiLiveService.kt
+++ b/samples/CameraAccessAndroid/app/src/main/java/com/meta/wearable/dat/externalsampleapps/cameraaccess/gemini/GeminiLiveService.kt
@@ -116,7 +116,8 @@ class GeminiLiveService {
             }
         })
 
-        // Timeout after 15 seconds (use Timer so we don't block sendExecutor)
+        // Cancel any previous timer before creating a new one (prevents leaks on repeated connect())
+        timeoutTimer?.cancel()
         timeoutTimer = Timer().apply {
             schedule(object : TimerTask() {
                 override fun run() {
@@ -134,6 +135,7 @@ class GeminiLiveService {
     fun disconnect() {
         timeoutTimer?.cancel()
         timeoutTimer = null
+        sendExecutor.shutdownNow()
         webSocket?.close(1000, null)
         webSocket = null
         onToolCall = null

--- a/samples/CameraAccessAndroid/app/src/main/java/com/meta/wearable/dat/externalsampleapps/cameraaccess/webrtc/WebRTCClient.kt
+++ b/samples/CameraAccessAndroid/app/src/main/java/com/meta/wearable/dat/externalsampleapps/cameraaccess/webrtc/WebRTCClient.kt
@@ -129,7 +129,8 @@ class WebRTCClient(private val context: Context) {
         // Create video source + track with custom capturer
         val factory = peerConnectionFactory ?: return
         videoSource = factory.createVideoSource(false) // false = not a screen cast
-        customCapturer = CustomVideoCapturer().apply { initialize(videoSource!!) }
+        val source = videoSource ?: return
+        customCapturer = CustomVideoCapturer().apply { initialize(source) }
         localVideoTrack = factory.createVideoTrack("video0", videoSource).apply {
             setEnabled(true)
         }

--- a/samples/CameraAccessAndroid/app/src/main/res/xml/network_security_config.xml
+++ b/samples/CameraAccessAndroid/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <!-- Allow cleartext only for local network (OpenClaw gateway on LAN) -->
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">localhost</domain>
+        <domain includeSubdomains="true">127.0.0.1</domain>
+        <domain includeSubdomains="true">10.0.0.0/8</domain>
+        <domain includeSubdomains="true">192.168.0.0/16</domain>
+        <domain includeSubdomains="true">172.16.0.0/12</domain>
+    </domain-config>
+    <!-- Block cleartext for all other domains (enforce HTTPS) -->
+    <base-config cleartextTrafficPermitted="false" />
+</network-security-config>


### PR DESCRIPTION
## Changes

### 1. Replace `usesCleartextTraffic=true` with network security config
`AndroidManifest.xml` had `android:usesCleartextTraffic="true"`, allowing all HTTP traffic in plaintext. Replaced with a `network_security_config.xml` that only permits cleartext for local network addresses (localhost, 10.x, 192.168.x, 172.16.x) where the OpenClaw gateway typically runs.

### 2. Fix Timer thread leak in GeminiLiveService
Calling `connect()` multiple times created new Timer objects without cancelling previous ones. Now cancels the existing timer before creating a new one.

### 3. Fix sendExecutor thread leak
`sendExecutor` (SingleThreadExecutor) was never shut down in `disconnect()`. Added `shutdownNow()` call.

### 4. Fix WebRTCClient NPE crash
`videoSource!!` force-unwrap replaced with safe null check (`val source = videoSource ?: return`).

## Files Changed
- `AndroidManifest.xml` — network security config reference
- `res/xml/network_security_config.xml` — new, cleartext only for LAN
- `gemini/GeminiLiveService.kt` — timer + executor fixes
- `webrtc/WebRTCClient.kt` — null safety fix

## Test plan
- [ ] App connects to OpenClaw on local network (HTTP still works for LAN)
- [ ] App fails gracefully for cleartext to public URLs
- [ ] Repeated connect/disconnect doesn't leak threads
- [ ] WebRTC works when videoSource is valid, doesn't crash when null

🤖 Generated with [Claude Code](https://claude.com/claude-code)