### PR TITLE
feat: Restore OpenClaw direct connection with remote HTTPS + agent routing

### DIFF
--- a/agent/.env.example
+++ b/agent/.env.example
@@ -36,3 +36,9 @@ QUICK_ANSWER_TIMEOUT_MS=30000
 
 # Quick search (grounded Google search)
 QUICK_SEARCH_MODEL=gemini-3.5-flash-lite
+
+# SuiteCRM (for add_contact tool)
+# The add_contact tool pushes contacts to SuiteCRM. If not configured,
+# contacts fall back to being saved as tagged notes.
+SUITECRM_URL=https://crm.wembassy.com
+SUITECRM_TOKEN=your-suitecrm-access-token

--- a/agent/.env.example
+++ b/agent/.env.example
@@ -1,0 +1,38 @@
+# VisionClaw Agent Worker Environment Variables
+
+# LiveKit connection (required for all engines)
+LIVEKIT_URL=wss://your-livekit.example.com
+LIVEKIT_API_KEY=your-api-key
+LIVEKIT_API_SECRET=your-api-secret
+
+# Gemini Live (default realtime engine)
+GOOGLE_API_KEY=your-google-api-key
+GEMINI_MODEL=gemini-2.5-flash-native-audio-preview-12-2025
+GEMINI_VOICE=Puck
+
+# OpenAI Realtime (optional realtime engine)
+# OPENAI_API_KEY=your-openai-api-key
+# OPENAI_REALTIME_MODEL=gpt-realtime-2.1
+
+# VisionClaw gateway (tool execution backend)
+GATEWAY_URL=https://your-gateway.example.com
+GATEWAY_SERVICE_TOKEN=your-service-token
+
+# OpenClaw direct engine (optional)
+# When engine="openclaw" is selected, the agent uses OpenClaw's
+# /v1/chat/completions endpoint instead of a realtime model.
+# Speech → Google STT → OpenClaw LLM → Google TTS → speech.
+# The session key routes to a specific Wembassy agent.
+OPENCLAW_URL=https://openclaw.wembassy.com
+OPENCLAW_TOKEN=your-openclaw-gateway-token
+# Default session key if not provided by the app
+OPENCLAW_SESSION_KEY=agent:coo:glass
+
+# Agent behavior
+AGENT_MODEL=claude-sonnet-5
+AGENT_EFFORT=low
+SPAWN_MODE=true
+QUICK_ANSWER_TIMEOUT_MS=30000
+
+# Quick search (grounded Google search)
+QUICK_SEARCH_MODEL=gemini-3.5-flash-lite

--- a/agent/main.py
+++ b/agent/main.py
@@ -833,7 +833,37 @@ async def browse(ctx: RunContext[Userdata], task: str) -> str:
     return await _run_delegated(ctx, task, "browse", job, on_deliver=on_deliver)
 
 
-def build_llm(engine: str):
+def build_llm(engine: str, session_key: str | None = None):
+    if engine == "openclaw":
+        # OpenClaw direct mode: LiveKit is just the audio/video transport.
+        # User speech → Google STT → OpenClaw /v1/chat/completions → Google TTS → spoken reply.
+        # The session key routes to a specific agent (e.g. "agent:coo:glass" → Wren).
+        openclaw_url = os.environ.get("OPENCLAW_URL", "https://openclaw.wembassy.com")
+        openclaw_token = os.environ.get("OPENCLAW_TOKEN", "")
+        openclaw_sk = session_key or os.environ.get("OPENCLAW_SESSION_KEY", "agent:main:glass")
+        if not openclaw_token:
+            logger.warning("openclaw engine selected but OPENCLAW_TOKEN unset; falling back to gemini")
+            engine = "gemini"
+        else:
+            logger.info("openclaw engine: url=%s session_key=%s", openclaw_url, openclaw_sk)
+            from livekit.plugins.openai import LLM as OpenAILLM
+            openclaw_llm = OpenAILLM(
+                model="openclaw",
+                base_url=f"{openclaw_url.rstrip('/')}/v1",
+                api_key=openclaw_token,
+                extra_headers={
+                    "x-openclaw-session-key": openclaw_sk,
+                    "x-openclaw-message-channel": "glass",
+                },
+            )
+            # Google STT + TTS for audio I/O (same provider as the default realtime model)
+            from livekit.plugins.google import STT as GoogleSTT, TTS as GoogleTTS
+            return {
+                "llm": openclaw_llm,
+                "stt": GoogleSTT(),
+                "tts": GoogleTTS(),
+            }
+
     if engine == "openai":
         if not os.environ.get("OPENAI_API_KEY"):
             logger.warning("openai engine requested but OPENAI_API_KEY unset; using gemini")
@@ -953,7 +983,8 @@ async def entrypoint(ctx: JobContext):
         meta = {}
     engine = meta.get("engine", "gemini")
     user_id = participant.identity or "demo"
-    logger.info("session start: user=%s engine=%s", user_id, engine)
+    agent_session_key = meta.get("agentSessionKey") or None
+    logger.info("session start: user=%s engine=%s agent=%s", user_id, engine, agent_session_key or "default")
 
     frames = FrameHolder()
     _watch_video(ctx, frames)
@@ -1043,8 +1074,26 @@ async def entrypoint(ctx: JobContext):
 
     show_card = function_tool(_show_card, name="show_card")
 
+    # Engine choice and agent routing come from participant metadata set by the app.
+    agent_session_key = meta.get("agentSessionKey") or None
     userdata = Userdata(user_id=user_id, frames=frames, tracer=tracer, room=ctx.room)
-    session = AgentSession(llm=build_llm(engine), userdata=userdata)
+    llm_result = build_llm(engine, session_key=agent_session_key)
+
+    if isinstance(llm_result, dict):
+        # OpenClaw mode: separate STT + LLM + TTS components
+        session = AgentSession(
+            stt=llm_result["stt"],
+            llm=llm_result["llm"],
+            tts=llm_result["tts"],
+            userdata=userdata,
+        )
+    else:
+        # Realtime mode (Gemini/OpenAI): single model handles audio I/O
+        session = AgentSession(llm=llm_result, userdata=userdata)
+
+    # When in OpenClaw mode, the agent's tools (execute, browse, etc.) still
+    # proxy through the VisionClaw gateway. The OpenClaw agent itself handles
+    # the conversation; tool calls are for the user's connected accounts.
 
     # The transcript pair the study runs on: final ASR of what the user said,
     # and the voice model's spoken reply (from output transcription). Items with

--- a/agent/main.py
+++ b/agent/main.py
@@ -91,7 +91,19 @@ website, including shopping or adding to a cart, use browse instead, even when t
 "an action". Speak a brief natural acknowledgment BEFORE calling it, never call it silently. Results may arrive as a follow-up; relay them as the
 answer to what was asked, not as a notification. If the task is about something the user
 is showing on camera, set attach_view=true so the actual image travels with the task --
-still describe what you see in the task text as well."""
+still describe what you see in the task text as well.
+
+SOCIAL SCAN: When the user says "scan this person", "who is this", "look them up", or similar,
+use the social_scan tool. It captures a single frame from the camera, reads the person's name
+tag or badge, and searches the web for their public bio. A card with their info appears on screen.
+This works without continuous video streaming — one snapshot frame is enough. If no name is
+visible, ask the user to say the person's name and use quick_search instead.
+
+ADD CONTACT: After a social scan (or when the user says "add to contacts", "save contact",
+"add this person"), use the add_contact tool. If called right after a scan with no arguments,
+it automatically uses the scanned person's data. The contact is saved to SuiteCRM (the CRM).
+If SuiteCRM is not configured, it falls back to saving as a tagged note. A confirmation card
+appears on screen when saved."""
 
 
 class FrameHolder:
@@ -203,6 +215,8 @@ class Userdata:
     # model tends to re-fire the tool when the first is slow (double-fire), and
     # two live CUA runs mean double cost and duplicate relays.
     browse_job: "asyncio.Future[str] | None" = None
+    # Last social_scan result, so add_contact can use it without re-scanning.
+    last_scan: dict | None = None
 
 
 _RELAY_STOPWORDS = {"finished", "earlier", "result", "research", "summary", "shopping", "however", "because"}
@@ -550,6 +564,294 @@ async def delete_note(ctx: RunContext[Userdata], match: str, tag: str | None = N
     ctx.userdata.tracer.emit("agent_action", tool="delete_note", match=match, tag=tag, deleted=deleted)
     await _push_notes_card(ctx, tag)
     return f"Removed: {deleted}. The updated list card is already on screen; confirm briefly."
+
+
+# ---------------------------------------------------------------------------
+# Social Scan — capture a single frame from the glasses, read a name tag,
+# search the web for that person, and return a bio card. Battery-friendly:
+# no continuous video streaming needed.
+# ---------------------------------------------------------------------------
+
+@function_tool
+async def social_scan(ctx: RunContext[Userdata]) -> str:
+    """Scan the person in front of the camera: capture a single frame, read
+    their name tag (name, company, role), and search the web for their public
+    profile. Returns a bio summary and shows a card on screen. Use when the
+    user says "scan this person", "who is this", or "look them up". Works
+    without continuous video — captures one snapshot frame."""
+    t0 = time.monotonic()
+    # Grab the current frame from the video track (or a frozen one)
+    image_b64 = encode_latest_frame(ctx.userdata.frames)
+    if not image_b64:
+        return ("I don't have a camera frame to scan. Make sure the glasses or phone camera "
+                "is active, then try again.")
+
+    # Step 1: Use Gemini vision to extract name/company from the frame (name tag reading)
+    try:
+        search_client = _get_search_client()
+        vision_resp = await search_client.aio.models.generate_content(
+            model=os.environ.get("QUICK_SEARCH_MODEL", "gemini-3.5-flash-lite"),
+            contents=[
+                genai_types.Part.from_bytes(data=base64.b64decode(image_b64), mime_type="image/jpeg"),
+                "Extract the person's name and affiliation from any visible name tag, badge, or "
+                "text in this image. Also note any other visible details (company logo, job title, "
+                "event name). Return as JSON: {\"name\": \"\", \"company\": \"\", \"title\": \"\", "
+                "\"other\": \"\"}. If no name is visible, return {\"name\": null}.",
+            ],
+            config=genai_types.GenerateContentConfig(
+                response_mime_type="application/json",
+                thinking_config=genai_types.ThinkingConfig(thinking_level="low"),
+            ),
+        )
+        import json as _json
+        vision_data = _json.loads(vision_resp.text or "{}")
+    except Exception as e:
+        logger.exception("social_scan vision failed: user=%s", ctx.userdata.user_id)
+        ctx.userdata.tracer.emit("agent_action", tool="social_scan", error=True, stage="vision")
+        return f"I couldn't read the frame. Error: {e}. Ask the user to say the person's name instead."
+
+    name = (vision_data.get("name") or "").strip()
+    company = (vision_data.get("company") or "").strip()
+    title = (vision_data.get("title") or "").strip()
+    other = (vision_data.get("other") or "").strip()
+
+    if not name:
+        ctx.userdata.tracer.emit("agent_action", tool="social_scan", stage="vision", no_name=True)
+        return ("I couldn't read a name from what I see. Ask the user to say the person's name "
+                "and company, then use quick_search to look them up.")
+
+    logger.info("social_scan: name=%s company=%s title=%s", name, company, title)
+
+    # Step 2: Web search for the person
+    query_parts = [name]
+    if company:
+        query_parts.append(company)
+    if title:
+        query_parts.append(title)
+    query = " ".join(query_parts)
+    # Add LinkedIn/social hints
+    search_query = f"{name} {company} {title} LinkedIn bio background".strip()
+
+    try:
+        search_resp = await search_client.aio.models.generate_content(
+            model=os.environ.get("QUICK_SEARCH_MODEL", "gemini-3.5-flash-lite"),
+            contents=search_query,
+            config=genai_types.GenerateContentConfig(
+                tools=[genai_types.Tool(google_search=genai_types.GoogleSearch())],
+                thinking_config=genai_types.ThinkingConfig(thinking_level="low"),
+            ),
+        )
+        bio_text = (search_resp.text or "").strip()
+    except Exception:
+        logger.exception("social_scan search failed: user=%s query=%r", ctx.userdata.user_id, search_query[:120])
+        bio_text = ""
+
+    # Step 3: Build and show a bio card
+    facts = []
+    if name:
+        facts.append({"label": "Name", "value": name})
+    if title:
+        facts.append({"label": "Title", "value": title})
+    if company:
+        facts.append({"label": "Company", "value": company})
+    if other:
+        facts.append({"label": "Notes", "value": other})
+
+    # If search found bio info, add a summary
+    if bio_text:
+        # Truncate to keep card readable
+        bio_summary = bio_text[:500]
+    else:
+        bio_summary = "No public bio found."
+
+    latency = round(time.monotonic() - t0, 2)
+    logger.info("social_scan complete: name=%s latency_s=%.2f bio_len=%d", name, latency, len(bio_text or ""))
+    ctx.userdata.tracer.emit(
+        "agent_action",
+        tool="social_scan",
+        name=name,
+        company=company,
+        title=title,
+        latency_s=latency,
+        bio_len=len(bio_text or ""),
+    )
+
+    # Store scan result in userdata so add_contact can use it
+    ctx.userdata.last_scan = {
+        "name": name,
+        "title": title,
+        "company": company,
+        "other": other,
+        "bio": bio_text or "",
+    }
+
+    # Show a card with the scan results
+    import json as _json2
+    await ctx.room.local_participant.send_text(
+        _json2.dumps({
+            "uuid": "social-scan",
+            "version": 1,
+            "type": "info",
+            "title": name,
+            "value": f"{title} at {company}" if title and company else (title or company or ""),
+            "body": bio_summary,
+            "facts": facts,
+            "fallback_text": f"{name}, {title} at {company}" if title and company else name,
+        }),
+        topic="vc.ui",
+    )
+
+    # Spoken summary for the user
+    spoken = f"Scanned: {name}"
+    if title:
+        spoken += f", {title}"
+    if company:
+        spoken += f" at {company}"
+    if bio_text:
+        # Add a key fact from the bio
+        spoken += f". {bio_text[:200]}"
+    return spoken + ". Card shown on screen. Say 'add to contacts' to save them."
+
+
+# ---------------------------------------------------------------------------
+# Add Contact — push contact info to SuiteCRM via REST API
+# ---------------------------------------------------------------------------
+
+@function_tool
+async def add_contact(
+    ctx: RunContext[Userdata],
+    first_name: str | None = None,
+    last_name: str | None = None,
+    email: str | None = None,
+    phone: str | None = None,
+    company: str | None = None,
+    title: str | None = None,
+    notes: str | None = None,
+) -> str:
+    """Add a contact to the CRM (SuiteCRM). Use after a social scan or when
+    the user says "add this person to contacts", "save contact", or "add to
+    my contacts". If called right after social_scan with no arguments, it
+    uses the scanned person's data automatically."""
+    # If no name provided, try to use the last scan result
+    if not first_name and not last_name and hasattr(ctx.userdata, 'last_scan') and ctx.userdata.last_scan:
+        scan = ctx.userdata.last_scan
+        full_name = scan.get("name", "")
+        # Try to split into first/last
+        parts = full_name.split(" ", 1)
+        first_name = parts[0] if parts else ""
+        last_name = parts[1] if len(parts) > 1 else ""
+        if not company:
+            company = scan.get("company", "")
+        if not title:
+            title = scan.get("title", "")
+        if not notes:
+            bio = scan.get("bio", "")
+            other = scan.get("other", "")
+            note_parts = []
+            if bio:
+                note_parts.append(f"Bio: {bio[:300]}")
+            if other:
+                note_parts.append(f"Notes: {other}")
+            notes = " | ".join(note_parts) if note_parts else None
+        logger.info("add_contact: using scan data for %s %s", first_name, last_name)
+
+    if not first_name and not last_name:
+        return ("I don't have a name to save. Either scan the person first (say 'scan this person') "
+                "or tell me their name.")
+
+    # SuiteCRM REST API
+    suitecrm_url = os.environ.get("SUITECRM_URL", "").rstrip("/")
+    suitecrm_token = os.environ.get("SUITECRM_TOKEN", "")
+
+    if not suitecrm_url or not suitecrm_token:
+        # Fallback: save as a note instead
+        contact_summary = f"{first_name} {last_name or ''}".strip()
+        if company:
+            contact_summary += f" ({company})"
+        if title:
+            contact_summary += f" - {title}"
+        if email:
+            contact_summary += f" email={email}"
+        if phone:
+            contact_summary += f" phone={phone}"
+        if notes:
+            contact_summary += f" notes={notes}"
+        try:
+            await _notes_call("POST", ctx.userdata.user_id, {"text": contact_summary, "tag": "contacts"})
+            ctx.userdata.tracer.emit("agent_action", tool="add_contact", fallback="note", name=contact_summary)
+            return f"SuiteCRM not configured. Saved {contact_summary} as a note with tag 'contacts' instead."
+        except Exception:
+            return "I couldn't save the contact — SuiteCRM is not configured and the note also failed."
+
+    # Build SuiteCRM contact payload
+    contact_data = {
+        "data": {
+            "type": "Contacts",
+            "attributes": {
+                "first_name": first_name or "",
+                "last_name": last_name or "",
+                "title": title or "",
+                "account_name": company or "",
+                "email1": email or "",
+                "phone_work": phone or "",
+                "description": notes or "",
+            },
+        }
+    }
+
+    try:
+        headers = {
+            "Authorization": f"Bearer {suitecrm_token}",
+            "Content-Type": "application/vnd.api+json",
+            "Accept": "application/vnd.api+json",
+        }
+        async with aiohttp.ClientSession() as http:
+            async with http.post(
+                f"{suitecrm_url}/Api/V8/module/Contacts",
+                headers=headers,
+                json=contact_data,
+                timeout=aiohttp.ClientTimeout(total=15),
+            ) as resp:
+                body_text = await resp.text()
+                if resp.status in (200, 201):
+                    logger.info("add_contact: saved to SuiteCRM: %s %s", first_name, last_name)
+                    ctx.userdata.tracer.emit(
+                        "agent_action",
+                        tool="add_contact",
+                        name=f"{first_name} {last_name}",
+                        company=company,
+                        suitecrm=True,
+                    )
+                    display_name = f"{first_name} {last_name or ''}".strip()
+                    # Show confirmation card
+                    import json as _json3
+                    await ctx.room.local_participant.send_text(
+                        _json3.dumps({
+                            "uuid": "contact-saved",
+                            "version": 1,
+                            "type": "info",
+                            "title": "Contact Saved",
+                            "value": display_name,
+                            "facts": [
+                                {"label": "Name", "value": display_name},
+                                {"label": "Company", "value": company or "—"},
+                                {"label": "Title", "value": title or "—"},
+                                {"label": "Email", "value": email or "—"},
+                                {"label": "Phone", "value": phone or "—"},
+                                {"label": "CRM", "value": "SuiteCRM"},
+                            ],
+                            "fallback_text": f"Contact saved: {display_name}",
+                        }),
+                        topic="vc.ui",
+                    )
+                    return f"Contact saved to SuiteCRM: {display_name}" + (f" at {company}" if company else "") + ". Card shown."
+                else:
+                    logger.error("add_contact: SuiteCRM error %d: %s", resp.status, body_text[:200])
+                    return f"SuiteCRM returned an error (status {resp.status}). Tell the user the contact couldn't be saved."
+    except Exception as e:
+        logger.exception("add_contact: request failed")
+        ctx.userdata.tracer.emit("agent_action", tool="add_contact", error=True, stage="suitecrm")
+        return f"I couldn't reach SuiteCRM: {e}. Tell the user and offer to save as a note instead."
 
 
 async def _gateway_browse_start(user_id: str, task: str) -> dict:
@@ -1119,7 +1421,7 @@ async def entrypoint(ctx: JobContext):
     await session.start(
         agent=Agent(
             instructions=INSTRUCTIONS,
-            tools=[execute, browse, quick_search, show_card, save_note, recall_notes, delete_note],
+            tools=[execute, browse, quick_search, show_card, save_note, recall_notes, delete_note, social_scan, add_contact],
         ),
         room=ctx.room,
         # Video is opt-in (RoomInputOptions.video_enabled defaults to False);

--- a/agent/main.py
+++ b/agent/main.py
@@ -103,7 +103,28 @@ ADD CONTACT: After a social scan (or when the user says "add to contacts", "save
 "add this person"), use the add_contact tool. If called right after a scan with no arguments,
 it automatically uses the scanned person's data. The contact is saved to SuiteCRM (the CRM).
 If SuiteCRM is not configured, it falls back to saving as a tagged note. A confirmation card
-appears on screen when saved."""
+appears on screen when saved.
+
+TECH X-RAY: When the user says "tech x-ray", "what is this device", "what laptop is that",
+or points at a product, use the tech_xray tool. It captures a frame, identifies the device
+from logos/model numbers, and returns specs, price, and reviews. Card shown on screen.
+
+COMPANY INTEL: When the user says "company intel", "what does this company do", "scan this
+booth", or points at a logo/booth, use the company_intel tool. It identifies the company and
+returns a brief: funding, team size, tech stack, recent news, competitors.
+
+WHITEBOARD CAPTURE: When the user says "capture this", "save this whiteboard", "scan this
+diagram", or points at a slide/diagram, use the capture_whiteboard tool. It transcribes all
+visible text and structure and saves it as a note.
+
+TECH TRIVIA: When the user says "fun fact", "tech trivia", "surprise me", or "tell me
+something interesting", use the tech_trivia tool. It identifies what's visible and finds a
+fascinating or lesser-known fact about it. Great for conference conversations.
+
+DEMO MODE: When the user says "demo mode", "start demo", "show me what this can do", or
+"introduce yourself" (especially to a new person), use the start_demo tool. It walks through
+all features with scripted narration and on-screen cards, pausing between each. After the
+demo, the viewer can try any feature for real by saying the trigger phrase."""
 
 
 class FrameHolder:
@@ -711,6 +732,446 @@ async def social_scan(ctx: RunContext[Userdata]) -> str:
         # Add a key fact from the bio
         spoken += f". {bio_text[:200]}"
     return spoken + ". Card shown on screen. Say 'add to contacts' to save them."
+
+
+# ---------------------------------------------------------------------------
+# Tech X-Ray — identify a device/product and return specs + review
+# ---------------------------------------------------------------------------
+
+@function_tool
+async def tech_xray(ctx: RunContext[Userdata]) -> str:
+    """Identify a device, product, or gadget in the camera frame and return
+    specs, price, and a quick review summary. Use when the user says
+    "what is this device", "tech x-ray", "what laptop is that", or similar.
+    Captures a single snapshot frame — no continuous video needed."""
+    image_b64 = encode_latest_frame(ctx.userdata.frames)
+    if not image_b64:
+        return "I don't have a camera frame. Make sure the camera is active and try again."
+
+    search_client = _get_search_client()
+    t0 = time.monotonic()
+
+    # Step 1: Vision model identifies the device
+    try:
+        resp = await search_client.aio.models.generate_content(
+            model=os.environ.get("QUICK_SEARCH_MODEL", "gemini-3.5-flash-lite"),
+            contents=[
+                genai_types.Part.from_bytes(data=base64.b64decode(image_b64), mime_type="image/jpeg"),
+                "Identify the device, product, or gadget in this image. Look for brand logos, "
+                "model numbers, form factors, distinctive design features. Return JSON: "
+                '{"name": "", "brand": "", "model": "", "category": "", "details": ""}. '
+                "If you cannot identify it, return {\"name\": null}.",
+            ],
+            config=genai_types.GenerateContentConfig(
+                response_mime_type="application/json",
+                thinking_config=genai_types.ThinkingConfig(thinking_level="low"),
+            ),
+        )
+        import json as _j
+        data = _j.loads(resp.text or "{}")
+    except Exception as e:
+        ctx.userdata.tracer.emit("agent_action", tool="tech_xray", error=True)
+        return f"I couldn't analyze the frame: {e}. Ask the user to describe it instead."
+
+    name = (data.get("name") or "").strip()
+    brand = (data.get("brand") or "").strip()
+    model = (data.get("model") or "").strip()
+    category = (data.get("category") or "").strip()
+
+    if not name:
+        return "I couldn't identify the device. Ask the user to tell you what it is, then use quick_search."
+
+    # Step 2: Search for specs/reviews
+    query = f"{name} {brand} {model} specs price review"
+    try:
+        search_resp = await search_client.aio.models.generate_content(
+            model=os.environ.get("QUICK_SEARCH_MODEL", "gemini-3.5-flash-lite"),
+            contents=query,
+            config=genai_types.GenerateContentConfig(
+                tools=[genai_types.Tool(google_search=genai_types.GoogleSearch())],
+                thinking_config=genai_types.ThinkingConfig(thinking_level="low"),
+            ),
+        )
+        info_text = (search_resp.text or "").strip()
+    except Exception:
+        info_text = ""
+
+    latency = round(time.monotonic() - t0, 2)
+    ctx.userdata.tracer.emit("agent_action", tool="tech_xray", name=name, latency_s=latency)
+
+    # Show card
+    facts = [
+        {"label": "Device", "value": name},
+        {"label": "Brand", "value": brand or "—"},
+    ]
+    if model:
+        facts.append({"label": "Model", "value": model})
+    if category:
+        facts.append({"label": "Category", "value": category})
+
+    import json as _j2
+    await ctx.room.local_participant.send_text(
+        _j2.dumps({
+            "uuid": "tech-xray", "version": 1, "type": "info",
+            "title": name, "value": f"{brand} {model}".strip() or category,
+            "body": (info_text or "No specs found.")[:500],
+            "facts": facts,
+            "fallback_text": f"Tech X-Ray: {name}",
+        }), topic="vc.ui")
+
+    spoken = f"Tech X-Ray: {name}"
+    if brand:
+        spoken += f" by {brand}"
+    if info_text:
+        spoken += f". {info_text[:200]}"
+    return spoken + ". Card shown on screen."
+
+
+# ---------------------------------------------------------------------------
+# Company Intel — identify a company from a logo/booth and return a brief
+# ---------------------------------------------------------------------------
+
+@function_tool
+async def company_intel(ctx: RunContext[Userdata]) -> str:
+    """Identify a company from a logo, booth, or signage in the camera frame
+    and return a business intelligence brief: funding, team size, tech stack,
+    recent news, competitors. Use when the user says "what does this company
+    do", "company intel", "scan this booth", or similar."""
+    image_b64 = encode_latest_frame(ctx.userdata.frames)
+    if not image_b64:
+        return "I don't have a camera frame. Make sure the camera is active and try again."
+
+    search_client = _get_search_client()
+    t0 = time.monotonic()
+
+    # Step 1: Vision reads the company name/logo
+    try:
+        resp = await search_client.aio.models.generate_content(
+            model=os.environ.get("QUICK_SEARCH_MODEL", "gemini-3.5-flash-lite"),
+            contents=[
+                genai_types.Part.from_bytes(data=base64.b64decode(image_b64), mime_type="image/jpeg"),
+                "Identify the company from any visible logo, booth signage, or branding in this "
+                "image. Return JSON: {\"company\": \"\", \"tagline\": \"\", \"other_text\": \"\"}. "
+                "If you cannot identify the company, return {\"company\": null}.",
+            ],
+            config=genai_types.GenerateContentConfig(
+                response_mime_type="application/json",
+                thinking_config=genai_types.ThinkingConfig(thinking_level="low"),
+            ),
+        )
+        import json as _j3
+        data = _j3.loads(resp.text or "{}")
+    except Exception as e:
+        ctx.userdata.tracer.emit("agent_action", tool="company_intel", error=True)
+        return f"I couldn't analyze the frame: {e}."
+
+    company = (data.get("company") or "").strip()
+    tagline = (data.get("tagline") or "").strip()
+
+    if not company:
+        return "I couldn't identify the company. Ask the user to say the name and I'll search."
+
+    # Step 2: Search for company intel
+    query = f"{company} company funding team size tech stack competitors recent news"
+    try:
+        search_resp = await search_client.aio.models.generate_content(
+            model=os.environ.get("QUICK_SEARCH_MODEL", "gemini-3.5-flash-lite"),
+            contents=query,
+            config=genai_types.GenerateContentConfig(
+                tools=[genai_types.Tool(google_search=genai_types.GoogleSearch())],
+                thinking_config=genai_types.ThinkingConfig(thinking_level="low"),
+            ),
+        )
+        intel_text = (search_resp.text or "").strip()
+    except Exception:
+        intel_text = ""
+
+    latency = round(time.monotonic() - t0, 2)
+    ctx.userdata.tracer.emit("agent_action", tool="company_intel", company=company, latency_s=latency)
+
+    import json as _j4
+    await ctx.room.local_participant.send_text(
+        _j4.dumps({
+            "uuid": "company-intel", "version": 1, "type": "info",
+            "title": company,
+            "value": tagline or "Company Brief",
+            "body": (intel_text or "No intel found.")[:500],
+            "facts": [
+                {"label": "Company", "value": company},
+                {"label": "Tagline", "value": tagline or "—"},
+            ],
+            "fallback_text": f"Company Intel: {company}",
+        }), topic="vc.ui")
+
+    spoken = f"Company Intel: {company}"
+    if intel_text:
+        spoken += f". {intel_text[:200]}"
+    return spoken + ". Card shown on screen."
+
+
+# ---------------------------------------------------------------------------
+# Capture Whiteboard — transcribe a whiteboard/diagram and save to notes
+# ---------------------------------------------------------------------------
+
+@function_tool
+async def capture_whiteboard(ctx: RunContext[Userdata], tag: str = "whiteboard") -> str:
+    """Capture and transcribe a whiteboard, diagram, or presentation slide
+    from the camera. Saves the transcribed content as a note. Use when the
+    user says "capture this", "save this whiteboard", "scan this diagram",
+    or "save this slide"."""
+    image_b64 = encode_latest_frame(ctx.userdata.frames)
+    if not image_b64:
+        return "I don't have a camera frame. Make sure the camera is active and try again."
+
+    search_client = _get_search_client()
+    t0 = time.monotonic()
+
+    try:
+        resp = await search_client.aio.models.generate_content(
+            model=os.environ.get("QUICK_SEARCH_MODEL", "gemini-3.5-flash-lite"),
+            contents=[
+                genai_types.Part.from_bytes(data=base64.b64decode(image_b64), mime_type="image/jpeg"),
+                "Transcribe ALL text, diagrams, labels, and structure visible in this image. "
+                "If it's a whiteboard, capture the full content including arrows, boxes, and "
+                "relationships. If it's a slide, capture the title, bullet points, and any "
+                "diagrams. Return as structured text, preserving hierarchy with indentation. "
+                "Do NOT add commentary — just transcribe what you see.",
+            ],
+            config=genai_types.GenerateContentConfig(
+                thinking_config=genai_types.ThinkingConfig(thinking_level="low"),
+            ),
+        )
+        transcribed = (resp.text or "").strip()
+    except Exception as e:
+        ctx.userdata.tracer.emit("agent_action", tool="capture_whiteboard", error=True)
+        return f"I couldn't read the frame: {e}."
+
+    if not transcribed:
+        return "I couldn't read any text from what I see. Ask the user to describe it."
+
+    # Save as a note
+    try:
+        await _notes_call("POST", ctx.userdata.user_id, {"text": transcribed, "tag": tag})
+    except Exception:
+        logger.exception("capture_whiteboard: note save failed")
+
+    latency = round(time.monotonic() - t0, 2)
+    ctx.userdata.tracer.emit("agent_action", tool="capture_whiteboard", tag=tag, latency_s=latency, text_len=len(transcribed))
+
+    import json as _j5
+    await ctx.room.local_participant.send_text(
+        _j5.dumps({
+            "uuid": "whiteboard-capture", "version": 1, "type": "info",
+            "title": f"Captured: {tag}",
+            "value": f"{len(transcribed)} characters",
+            "body": transcribed[:500],
+            "fallback_text": f"Whiteboard captured to {tag}",
+        }), topic="vc.ui")
+
+    return f"Captured and saved to {tag}. The content is on screen. {len(transcribed)} characters transcribed."
+
+
+# ---------------------------------------------------------------------------
+# Tech Trivia — find a fascinating fact about a visible company/tech
+# ---------------------------------------------------------------------------
+
+@function_tool
+async def tech_trivia(ctx: RunContext[Userdata]) -> str:
+    """Find a fascinating or surprising tech fact about a company or technology
+    visible in the camera frame. Great for sparking conversations at a booth or
+    trade show. Use when the user says "fun fact", "tech trivia", "tell me
+    something interesting about this", or "surprise me"."""
+    image_b64 = encode_latest_frame(ctx.userdata.frames)
+    if not image_b64:
+        return "I don't have a camera frame. Make sure the camera is active and try again."
+
+    search_client = _get_search_client()
+    t0 = time.monotonic()
+
+    # Step 1: Vision identifies the company/tech
+    try:
+        resp = await search_client.aio.models.generate_content(
+            model=os.environ.get("QUICK_SEARCH_MODEL", "gemini-3.5-flash-lite"),
+            contents=[
+                genai_types.Part.from_bytes(data=base64.b64decode(image_b64), mime_type="image/jpeg"),
+                "Identify the company, technology, or product visible in this image. "
+                "Return JSON: {\"subject\": \"\", \"type\": \"\"}. "
+                "If unidentifiable, return {\"subject\": null}.",
+            ],
+            config=genai_types.GenerateContentConfig(
+                response_mime_type="application/json",
+                thinking_config=genai_types.ThinkingConfig(thinking_level="low"),
+            ),
+        )
+        import json as _j6
+        data = _j6.loads(resp.text or "{}")
+    except Exception as e:
+        ctx.userdata.tracer.emit("agent_action", tool="tech_trivia", error=True)
+        return f"I couldn't analyze the frame: {e}."
+
+    subject = (data.get("subject") or "").strip()
+    subject_type = (data.get("type") or "").strip()
+
+    if not subject:
+        return "I couldn't identify what to find trivia about. Ask the user to name it."
+
+    # Step 2: Search for fascinating facts
+    query = f"fascinating surprising lesser-known fact trivia about {subject} {subject_type} history origin story"
+    try:
+        search_resp = await search_client.aio.models.generate_content(
+            model=os.environ.get("QUICK_SEARCH_MODEL", "gemini-3.5-flash-lite"),
+            contents=query,
+            config=genai_types.GenerateContentConfig(
+                tools=[genai_types.Tool(google_search=genai_types.GoogleSearch())],
+                thinking_config=genai_types.ThinkingConfig(thinking_level="low"),
+            ),
+        )
+        trivia_text = (search_resp.text or "").strip()
+    except Exception:
+        trivia_text = ""
+
+    latency = round(time.monotonic() - t0, 2)
+    ctx.userdata.tracer.emit("agent_action", tool="tech_trivia", subject=subject, latency_s=latency)
+
+    import json as _j7
+    await ctx.room.local_participant.send_text(
+        _j7.dumps({
+            "uuid": "tech-trivia", "version": 1, "type": "info",
+            "title": f"Did you know? — {subject}",
+            "body": (trivia_text or "No trivia found.")[:500],
+            "fallback_text": f"Tech trivia about {subject}",
+        }), topic="vc.ui")
+
+    spoken = f"Here's something interesting about {subject}"
+    if trivia_text:
+        spoken += f". {trivia_text[:250]}"
+    return spoken + ". Card shown on screen."
+
+
+# ---------------------------------------------------------------------------
+# Demo Mode — scripted walkthrough of all features for showcasing
+# ---------------------------------------------------------------------------
+
+@function_tool
+async def start_demo(ctx: RunContext[Userdata]) -> str:
+    """Start a guided demo of VisionClaw's capabilities. Walks through each
+    feature with narration and on-screen cards, pausing between each so the
+    viewer can see the card. Use when the user says "demo mode", "start demo",
+    "show me what this can do", or "introduce yourself". The demo pauses after
+    each feature and tells the user what to point the camera at next."""
+    import json as _dj
+    room = ctx.room
+    t0 = time.monotonic()
+    ctx.userdata.tracer.emit("agent_action", tool="start_demo")
+
+    async def _card(payload: dict, delay: float = 3.0):
+        """Send a card and pause."""
+        await room.local_participant.send_text(_dj.dumps(payload), topic="vc.ui")
+        await asyncio.sleep(delay)
+
+    # Intro card
+    await _card({
+        "uuid": "demo-intro", "version": 1, "type": "info",
+        "title": "VisionClaw",
+        "value": "AI Glasses Assistant",
+        "body": "A walkthrough of what VisionClaw can do with smart glasses + AI.",
+        "facts": [
+            {"label": "Feature 1", "value": "Social Scan — identify people from name tags"},
+            {"label": "Feature 2", "value": "Tech X-Ray — identify devices + specs"},
+            {"label": "Feature 3", "value": "Company Intel — scan booths for company briefs"},
+            {"label": "Feature 4", "value": "Whiteboard Capture — transcribe diagrams"},
+            {"label": "Feature 5", "value": "Tech Trivia — fascinating facts about what you see"},
+            {"label": "Feature 6", "value": "Add to Contacts — save people to CRM"},
+        ],
+        "fallback_text": "VisionClaw demo mode",
+    }, delay=4)
+
+    yield_msg = "Welcome to VisionClaw. I'm an AI assistant that lives in your glasses. "
+    yield_msg += "I can see what you see and help you in real time. "
+    yield_msg += "Let me walk you through what I can do. "
+    yield_msg += "After each demo, point your camera at the next thing I mention. "
+    yield_msg += "Say 'next' when you're ready to continue."
+
+    # Feature 1: Social Scan
+    await _card({
+        "uuid": "demo-1", "version": 1, "type": "info",
+        "title": "1. Social Scan",
+        "value": "🔍 Identify people from name tags",
+        "body": "Point the camera at someone's name tag. I'll read their name, company, and title, "
+                "then search the web for their public bio. Say 'scan this person' to try it.",
+        "fallback_text": "Demo: Social Scan",
+    }, delay=3)
+    yield_msg += " First: Social Scan. Point at a name tag and say 'scan this person'. I'll read their name and find their bio."
+
+    # Feature 2: Tech X-Ray
+    await _card({
+        "uuid": "demo-2", "version": 1, "type": "info",
+        "title": "2. Tech X-Ray",
+        "value": "🔬 Identify devices + specs",
+        "body": "Point at any device — a laptop, phone, gadget. I'll identify it and pull specs, "
+                "price, and reviews. Say 'tech x-ray' to try it.",
+        "fallback_text": "Demo: Tech X-Ray",
+    }, delay=3)
+    yield_msg += " Next: Tech X-Ray. Point at any device and say 'tech x-ray'. I'll tell you what it is and its specs."
+
+    # Feature 3: Company Intel
+    await _card({
+        "uuid": "demo-3", "version": 1, "type": "info",
+        "title": "3. Company Intel",
+        "value": "📡 Scan booths for company briefs",
+        "body": "Point at a company logo or booth. I'll identify the company and pull funding info, "
+                "team size, tech stack, and recent news. Say 'company intel' to try it.",
+        "fallback_text": "Demo: Company Intel",
+    }, delay=3)
+    yield_msg += " Next: Company Intel. Point at a booth and say 'company intel'. I'll give you a full brief."
+
+    # Feature 4: Whiteboard Capture
+    await _card({
+        "uuid": "demo-4", "version": 1, "type": "info",
+        "title": "4. Whiteboard Capture",
+        "value": "📝 Transcribe diagrams + slides",
+        "body": "Point at a whiteboard, diagram, or presentation slide. I'll transcribe everything "
+                "and save it to your notes. Say 'capture this' to try it.",
+        "fallback_text": "Demo: Whiteboard Capture",
+    }, delay=3)
+    yield_msg += " Next: Whiteboard Capture. Point at a diagram and say 'capture this'."
+
+    # Feature 5: Tech Trivia
+    await _card({
+        "uuid": "demo-5", "version": 1, "type": "info",
+        "title": "5. Tech Trivia",
+        "value": "🎲 Fascinating facts about what you see",
+        "body": "Point at any company or technology. I'll find a surprising or lesser-known fact "
+                "about them. Great for sparking conversations. Say 'fun fact' to try it.",
+        "fallback_text": "Demo: Tech Trivia",
+    }, delay=3)
+    yield_msg += " Next: Tech Trivia. Point at a company and say 'fun fact'."
+
+    # Feature 6: Add to Contacts
+    await _card({
+        "uuid": "demo-6", "version": 1, "type": "info",
+        "title": "6. Add to Contacts",
+        "value": "📇 Save people to CRM",
+        "body": "After scanning someone, say 'add to contacts' and I'll save them to SuiteCRM "
+                "automatically. No typing, no business cards.",
+        "fallback_text": "Demo: Add to Contacts",
+    }, delay=3)
+    yield_msg += " Finally: Add to Contacts. After scanning someone, say 'add to contacts' and I'll save them to your CRM."
+
+    # Outro
+    await _card({
+        "uuid": "demo-outro", "version": 1, "type": "info",
+        "title": "That's VisionClaw",
+        "value": "6 features, zero typing",
+        "body": "All powered by a single pair of smart glasses + AI. "
+                "Say any command to try a feature for real, or say 'demo mode' to replay this.",
+        "fallback_text": "VisionClaw demo complete",
+    }, delay=2)
+
+    latency = round(time.monotonic() - t0, 2)
+    ctx.userdata.tracer.emit("agent_action", tool="start_demo", complete=True, latency_s=latency)
+
+    return yield_msg + " The demo cards are on screen. Say 'next' or ask me to try any feature for real."
 
 
 # ---------------------------------------------------------------------------
@@ -1421,7 +1882,7 @@ async def entrypoint(ctx: JobContext):
     await session.start(
         agent=Agent(
             instructions=INSTRUCTIONS,
-            tools=[execute, browse, quick_search, show_card, save_note, recall_notes, delete_note, social_scan, add_contact],
+            tools=[execute, browse, quick_search, show_card, save_note, recall_notes, delete_note, social_scan, add_contact, tech_xray, company_intel, capture_whiteboard, tech_trivia, start_demo],
         ),
         room=ctx.room,
         # Video is opt-in (RoomInputOptions.video_enabled defaults to False);

--- a/gateway/src/server.ts
+++ b/gateway/src/server.ts
@@ -438,13 +438,17 @@ app.post("/livekit-token", async (req, res) => {
   // setup and greeting time.
   void ensureUser(userId).catch((err) => console.warn(`[provision] pre-warm failed for ${userId}:`, err));
   const { AccessToken } = await import("livekit-server-sdk");
-  // The engine choice (gemini | openai) rides as participant metadata; the
+  // The engine choice (gemini | openai | openclaw) rides as participant metadata; the
   // worker reads it when the user joins and picks the realtime model.
-  const engine = req.body?.engine === "openai" ? "openai" : "gemini";
+  // For openclaw, agentSessionKey routes to a specific agent (e.g. "agent:coo:glass").
+  const engine = ["openai", "openclaw"].includes(req.body?.engine) ? req.body.engine : "gemini";
+  const agentSessionKey = typeof req.body?.agentSessionKey === "string" ? req.body.agentSessionKey : undefined;
+  const metadata: Record<string, unknown> = { engine };
+  if (agentSessionKey) metadata.agentSessionKey = agentSessionKey;
   const at = new AccessToken(LIVEKIT_API_KEY, LIVEKIT_API_SECRET, {
     identity: userId,
     ttl: "15m",
-    metadata: JSON.stringify({ engine }),
+    metadata: JSON.stringify(metadata),
   });
   // One room per call, not per user: agent dispatch fires on room creation,
   // so a redial into a still-draining room from the previous call would get

--- a/samples/CameraAccessAndroid/app/src/main/java/com/meta/wearable/dat/externalsampleapps/cameraaccess/Secrets.kt.example
+++ b/samples/CameraAccessAndroid/app/src/main/java/com/meta/wearable/dat/externalsampleapps/cameraaccess/Secrets.kt.example
@@ -10,4 +10,15 @@ object Secrets {
     // would make every install the same user).
     const val gatewayBaseUrl = "https://api.visionagents.app"
     const val gatewayToken = ""
+
+    // OpenClaw direct connection (alternative to the hosted gateway).
+    // Talks to an OpenClaw instance's /v1/chat/completions endpoint.
+    // The session key routes messages to a specific agent.
+    //   agent:cto:glass → Spock (CTO)
+    //   agent:coo:glass → Wren (COO)
+    //   agent:cmo:glass → Mason (CMO)
+    //   agent:cro:glass → Grayson (CRO)
+    const val openClawBaseUrl = "https://openclaw.wembassy.com"
+    const val openClawToken = "YOUR_OPENCLAW_GATEWAY_TOKEN"
+    const val openClawSessionKey = "agent:coo:glass"
 }

--- a/samples/CameraAccessAndroid/app/src/main/java/com/meta/wearable/dat/externalsampleapps/cameraaccess/livekit/LiveKitSessionViewModel.kt
+++ b/samples/CameraAccessAndroid/app/src/main/java/com/meta/wearable/dat/externalsampleapps/cameraaccess/livekit/LiveKitSessionViewModel.kt
@@ -802,6 +802,12 @@ class LiveKitSessionViewModel(
         val baseUrl = SettingsManager.gatewayBaseUrl.trimEnd('/')
         val body = JSONObject()
             .put("engine", engine.value)
+            .apply {
+                // For OpenClaw engine, pass the agent session key for routing
+                if (engine == IntelligenceEngine.OPENCLAW) {
+                    put("agentSessionKey", SettingsManager.openClawSessionKey)
+                }
+            }
             .toString()
             .toRequestBody("application/json".toMediaType())
         val request = Request.Builder()

--- a/samples/CameraAccessAndroid/app/src/main/java/com/meta/wearable/dat/externalsampleapps/cameraaccess/livekit/LiveKitSessionViewModel.kt
+++ b/samples/CameraAccessAndroid/app/src/main/java/com/meta/wearable/dat/externalsampleapps/cameraaccess/livekit/LiveKitSessionViewModel.kt
@@ -146,6 +146,8 @@ data class LiveKitUiState(
     val glassesStreaming: Boolean = false,
     val caption: Caption? = null,
     val card: UiCard? = null,
+    // Video can be muted during a call to save glasses battery — voice continues.
+    val videoMuted: Boolean = false,
 ) {
     val isActive: Boolean
         get() = state == SessionState.Connected || state == SessionState.Connecting
@@ -590,6 +592,7 @@ class LiveKitSessionViewModel(
                 zoomFactor = 1f,
                 caption = null,
                 card = null,
+                videoMuted = false,
             )
         }
     }
@@ -757,8 +760,67 @@ class LiveKitSessionViewModel(
     fun unfreeze() {
         if (_uiState.value.frozenFrame == null) return
         _uiState.update { it.copy(frozenFrame = null) }
-        if (_uiState.value.state == SessionState.Connected) {
+        if (_uiState.value.state == SessionState.Connected && !_uiState.value.videoMuted) {
             room.localParticipant.getTrackPublication(Track.Source.CAMERA)?.muted = false
+        }
+    }
+
+    // MARK: Video mute (voice-only mode)
+
+    /**
+     * Toggle video publishing during a call without dropping audio. When muted,
+     * the glasses stop streaming (battery save) and the agent receives no video
+     * frames — voice continues uninterrupted. The camera preview also stops so
+     * the glasses fully power down their video pipeline.
+     */
+    fun toggleVideoMute() {
+        val current = _uiState.value
+        if (current.state != SessionState.Connected) return
+        val newMuted = !current.videoMuted
+
+        if (newMuted) {
+            // Mute: stop publishing video to save glasses battery
+            if (current.isGlassesSource) {
+                // For glasses: stop the video track entirely so the glasses
+                // can power down their camera pipeline
+                current.localVideoTrack?.let { track ->
+                    track.stopCapture()
+                    room.localParticipant.unpublishTrack(track)
+                }
+            } else {
+                // For phone camera: mute the track (camera stays warm for quick resume)
+                room.localParticipant.getTrackPublication(Track.Source.CAMERA)?.muted = true
+            }
+            _uiState.update { it.copy(videoMuted = true, localVideoTrack = null) }
+        } else {
+            // Unmute: resume video publishing
+            if (current.isGlassesSource) {
+                // Restart glasses video track
+                viewModelScope.launch {
+                    try {
+                        ensureGlassesFeed()
+                        val capturer = GlassesVideoCapturer()
+                        val glassesTrack = room.localParticipant.createVideoTrack(
+                            name = "glasses",
+                            capturer = capturer,
+                        )
+                        glassesCapturer = capturer
+                        glassesTrack.startCapture()
+                        room.localParticipant.publishVideoTrack(glassesTrack)
+                        attachGrabber(glassesTrack)
+                        _uiState.update { it.copy(videoMuted = false, localVideoTrack = glassesTrack) }
+                    } catch (e: Exception) {
+                        Log.w(TAG, "failed to resume glasses video: ${e.message}")
+                        _uiState.update { it.copy(videoMuted = false) }
+                    }
+                }
+            } else {
+                // Unmute phone camera
+                room.localParticipant.getTrackPublication(Track.Source.CAMERA)?.muted = false
+                val track = room.localParticipant
+                    .getTrackPublication(Track.Source.CAMERA)?.track as? LocalVideoTrack
+                _uiState.update { it.copy(videoMuted = false, localVideoTrack = track) }
+            }
         }
     }
 

--- a/samples/CameraAccessAndroid/app/src/main/java/com/meta/wearable/dat/externalsampleapps/cameraaccess/openclaw/OpenClawBridge.kt
+++ b/samples/CameraAccessAndroid/app/src/main/java/com/meta/wearable/dat/externalsampleapps/cameraaccess/openclaw/OpenClawBridge.kt
@@ -1,0 +1,260 @@
+package com.meta.wearable.dat.externalsampleapps.cameraaccess.openclaw
+
+import android.util.Log
+import com.meta.wearable.dat.externalsampleapps.cameraaccess.settings.SettingsManager
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.withContext
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * Direct OpenClaw gateway bridge. Talks to an OpenClaw instance's
+ * /v1/chat/completions endpoint over HTTPS, with session-key routing to
+ * target a specific agent (e.g. "agent:coo:glass" → Wren).
+ *
+ * Restored from the pre-LiveKit migration and updated for:
+ * - Remote HTTPS URLs (no longer assumes localhost)
+ * - Session key routing via x-openclaw-session-key header
+ * - Settings sourced from SettingsManager (no GeminiConfig dependency)
+ */
+class OpenClawBridge {
+    companion object {
+        private const val TAG = "OpenClawBridge"
+        private const val MAX_HISTORY_TURNS = 10
+    }
+
+    private val _lastToolCallStatus = MutableStateFlow<ToolCallStatus>(ToolCallStatus.Idle)
+    val lastToolCallStatus: StateFlow<ToolCallStatus> = _lastToolCallStatus.asStateFlow()
+
+    private val _connectionState = MutableStateFlow<OpenClawConnectionState>(OpenClawConnectionState.NotConfigured)
+    val connectionState: StateFlow<OpenClawConnectionState> = _connectionState.asStateFlow()
+
+    fun setToolCallStatus(status: ToolCallStatus) {
+        _lastToolCallStatus.value = status
+    }
+
+    private val client = OkHttpClient.Builder()
+        .readTimeout(120, TimeUnit.SECONDS)
+        .connectTimeout(15, TimeUnit.SECONDS)
+        .build()
+
+    private val pingClient = OkHttpClient.Builder()
+        .readTimeout(5, TimeUnit.SECONDS)
+        .connectTimeout(5, TimeUnit.SECONDS)
+        .build()
+
+    private val conversationHistory = mutableListOf<JSONObject>()
+
+    val isConfigured: Boolean
+        get() = SettingsManager.isOpenClawConfigured
+
+    val sessionKey: String
+        get() = SettingsManager.openClawSessionKey
+
+    suspend fun checkConnection() = withContext(Dispatchers.IO) {
+        if (!SettingsManager.isOpenClawConfigured) {
+            _connectionState.value = OpenClawConnectionState.NotConfigured
+            return@withContext
+        }
+        _connectionState.value = OpenClawConnectionState.Checking
+
+        val url = "${SettingsManager.openClawBaseUrl.trimEnd('/')}/v1/chat/completions"
+        try {
+            val request = Request.Builder()
+                .url(url)
+                .get()
+                .addHeader("Authorization", "Bearer ${SettingsManager.openClawToken}")
+                .addHeader("x-openclaw-session-key", SettingsManager.openClawSessionKey)
+                .addHeader("x-openclaw-message-channel", "glass")
+                .build()
+
+            val response = pingClient.newCall(request).execute()
+            val code = response.code
+            response.close()
+
+            if (code in 200..499) {
+                _connectionState.value = OpenClawConnectionState.Connected
+                Log.d(TAG, "OpenClaw gateway reachable (HTTP $code)")
+            } else {
+                _connectionState.value = OpenClawConnectionState.Unreachable("HTTP $code")
+            }
+        } catch (e: Exception) {
+            _connectionState.value = OpenClawConnectionState.Unreachable(e.message ?: "Unknown error")
+            Log.d(TAG, "OpenClaw gateway unreachable: ${e.message}")
+        }
+    }
+
+    fun resetSession() {
+        conversationHistory.clear()
+        Log.d(TAG, "Session reset (key retained: ${SettingsManager.openClawSessionKey})")
+    }
+
+    /**
+     * Send a message to the OpenClaw agent and return the response text.
+     * Maintains conversation history for context across turns.
+     */
+    suspend fun sendMessage(
+        message: String,
+    ): ToolResult = withContext(Dispatchers.IO) {
+        val toolName = "chat"
+        _lastToolCallStatus.value = ToolCallStatus.Executing(toolName)
+
+        val url = "${SettingsManager.openClawBaseUrl.trimEnd('/')}/v1/chat/completions"
+
+        // Append user message
+        conversationHistory.add(JSONObject().apply {
+            put("role", "user")
+            put("content", message)
+        })
+
+        // Trim history
+        if (conversationHistory.size > MAX_HISTORY_TURNS * 2) {
+            val trimmed = conversationHistory.takeLast(MAX_HISTORY_TURNS * 2)
+            conversationHistory.clear()
+            conversationHistory.addAll(trimmed)
+        }
+
+        Log.d(TAG, "Sending ${conversationHistory.size} messages to ${SettingsManager.openClawSessionKey}")
+
+        try {
+            val messagesArray = JSONArray()
+            for (msg in conversationHistory) {
+                messagesArray.put(msg)
+            }
+
+            val body = JSONObject().apply {
+                put("model", "openclaw")
+                put("messages", messagesArray)
+                put("stream", false)
+            }
+
+            val request = Request.Builder()
+                .url(url)
+                .post(body.toString().toRequestBody("application/json".toMediaType()))
+                .addHeader("Authorization", "Bearer ${SettingsManager.openClawToken}")
+                .addHeader("Content-Type", "application/json")
+                .addHeader("x-openclaw-session-key", SettingsManager.openClawSessionKey)
+                .addHeader("x-openclaw-message-channel", "glass")
+                .build()
+
+            val response = client.newCall(request).execute()
+            val responseBody = response.body?.string() ?: ""
+            val statusCode = response.code
+            response.close()
+
+            if (statusCode !in 200..299) {
+                Log.e(TAG, "Chat failed: HTTP $statusCode - ${responseBody.take(200)}")
+                _lastToolCallStatus.value = ToolCallStatus.Failed(toolName, "HTTP $statusCode")
+                return@withContext ToolResult.Failure("Agent returned HTTP $statusCode: ${responseBody.take(100)}")
+            }
+
+            val json = JSONObject(responseBody)
+            val choices = json.optJSONArray("choices")
+            val content = choices?.optJSONObject(0)
+                ?.optJSONObject("message")
+                ?.optString("content", "")
+
+            if (!content.isNullOrEmpty()) {
+                conversationHistory.add(JSONObject().apply {
+                    put("role", "assistant")
+                    put("content", content)
+                })
+                Log.d(TAG, "Agent response: ${content.take(200)}")
+                _lastToolCallStatus.value = ToolCallStatus.Completed(toolName)
+                return@withContext ToolResult.Success(content)
+            }
+
+            _lastToolCallStatus.value = ToolCallStatus.Completed(toolName)
+            return@withContext ToolResult.Success(responseBody)
+        } catch (e: Exception) {
+            Log.e(TAG, "Agent error: ${e.message}")
+            _lastToolCallStatus.value = ToolCallStatus.Failed(toolName, e.message ?: "Unknown")
+            return@withContext ToolResult.Failure("Agent error: ${e.message}")
+        }
+    }
+
+    /**
+     * Delegate a task (legacy interface — same as sendMessage but with a
+     * tool name for status tracking).
+     */
+    suspend fun delegateTask(
+        task: String,
+        toolName: String = "execute"
+    ): ToolResult = withContext(Dispatchers.IO) {
+        _lastToolCallStatus.value = ToolCallStatus.Executing(toolName)
+
+        val url = "${SettingsManager.openClawBaseUrl.trimEnd('/')}/v1/chat/completions"
+
+        conversationHistory.add(JSONObject().apply {
+            put("role", "user")
+            put("content", task)
+        })
+
+        if (conversationHistory.size > MAX_HISTORY_TURNS * 2) {
+            val trimmed = conversationHistory.takeLast(MAX_HISTORY_TURNS * 2)
+            conversationHistory.clear()
+            conversationHistory.addAll(trimmed)
+        }
+
+        try {
+            val messagesArray = JSONArray()
+            for (msg in conversationHistory) {
+                messagesArray.put(msg)
+            }
+
+            val body = JSONObject().apply {
+                put("model", "openclaw")
+                put("messages", messagesArray)
+                put("stream", false)
+            }
+
+            val request = Request.Builder()
+                .url(url)
+                .post(body.toString().toRequestBody("application/json".toMediaType()))
+                .addHeader("Authorization", "Bearer ${SettingsManager.openClawToken}")
+                .addHeader("Content-Type", "application/json")
+                .addHeader("x-openclaw-session-key", SettingsManager.openClawSessionKey)
+                .addHeader("x-openclaw-message-channel", "glass")
+                .build()
+
+            val response = client.newCall(request).execute()
+            val responseBody = response.body?.string() ?: ""
+            val statusCode = response.code
+            response.close()
+
+            if (statusCode !in 200..299) {
+                _lastToolCallStatus.value = ToolCallStatus.Failed(toolName, "HTTP $statusCode")
+                return@withContext ToolResult.Failure("Agent returned HTTP $statusCode")
+            }
+
+            val json = JSONObject(responseBody)
+            val choices = json.optJSONArray("choices")
+            val content = choices?.optJSONObject(0)
+                ?.optJSONObject("message")
+                ?.optString("content", "")
+
+            if (!content.isNullOrEmpty()) {
+                conversationHistory.add(JSONObject().apply {
+                    put("role", "assistant")
+                    put("content", content)
+                })
+                _lastToolCallStatus.value = ToolCallStatus.Completed(toolName)
+                return@withContext ToolResult.Success(content)
+            }
+
+            _lastToolCallStatus.value = ToolCallStatus.Completed(toolName)
+            return@withContext ToolResult.Success(responseBody)
+        } catch (e: Exception) {
+            _lastToolCallStatus.value = ToolCallStatus.Failed(toolName, e.message ?: "Unknown")
+            return@withContext ToolResult.Failure("Agent error: ${e.message}")
+        }
+    }
+}

--- a/samples/CameraAccessAndroid/app/src/main/java/com/meta/wearable/dat/externalsampleapps/cameraaccess/openclaw/ToolCallModels.kt
+++ b/samples/CameraAccessAndroid/app/src/main/java/com/meta/wearable/dat/externalsampleapps/cameraaccess/openclaw/ToolCallModels.kt
@@ -1,0 +1,62 @@
+package com.meta.wearable.dat.externalsampleapps.cameraaccess.openclaw
+
+import org.json.JSONArray
+import org.json.JSONObject
+
+// Tool Result
+
+sealed class ToolResult {
+    data class Success(val result: String) : ToolResult()
+    data class Failure(val error: String) : ToolResult()
+
+    fun toJSON(): JSONObject = when (this) {
+        is Success -> JSONObject().put("result", result)
+        is Failure -> JSONObject().put("error", error)
+    }
+}
+
+// Tool Call Status (for UI)
+
+sealed class ToolCallStatus {
+    data object Idle : ToolCallStatus()
+    data class Executing(val name: String) : ToolCallStatus()
+    data class Completed(val name: String) : ToolCallStatus()
+    data class Failed(val name: String, val error: String) : ToolCallStatus()
+    data class Cancelled(val name: String) : ToolCallStatus()
+
+    val displayText: String
+        get() = when (this) {
+            is Idle -> ""
+            is Executing -> "Running: $name..."
+            is Completed -> "Done: $name"
+            is Failed -> "Failed: $name - $error"
+            is Cancelled -> "Cancelled: $name"
+        }
+
+    val isActive: Boolean
+        get() = this is Executing
+}
+
+// OpenClaw Connection State
+
+sealed class OpenClawConnectionState {
+    data object NotConfigured : OpenClawConnectionState()
+    data object Checking : OpenClawConnectionState()
+    data object Connected : OpenClawConnectionState()
+    data class Unreachable(val message: String) : OpenClawConnectionState()
+}
+
+// Agent selector — maps display names to OpenClaw session keys
+
+enum class OpenClawAgent(val displayName: String, val sessionKey: String) {
+    SPOCK("Spock (CTO)", "agent:cto:glass"),
+    WREN("Wren (COO)", "agent:coo:glass"),
+    MASON("Mason (CMO)", "agent:cmo:glass"),
+    GRAYSON("Grayson (CRO)", "agent:cro:glass"),
+    MAIN("Default Agent", "agent:main:glass");
+
+    companion object {
+        fun fromSessionKey(key: String): OpenClawAgent =
+            entries.firstOrNull { it.sessionKey == key } ?: MAIN
+    }
+}

--- a/samples/CameraAccessAndroid/app/src/main/java/com/meta/wearable/dat/externalsampleapps/cameraaccess/settings/SettingsManager.kt
+++ b/samples/CameraAccessAndroid/app/src/main/java/com/meta/wearable/dat/externalsampleapps/cameraaccess/settings/SettingsManager.kt
@@ -133,6 +133,29 @@ object SettingsManager {
         get() = prefs.getString("webrtcSignalingURL", null) ?: DEFAULT_SIGNALING_URL
         set(value) = prefs.edit().putString("webrtcSignalingURL", value).apply()
 
+    // --- OpenClaw direct connection settings ---
+
+    /** Base URL of the OpenClaw gateway (e.g. "https://openclaw.wembassy.com"). */
+    var openClawBaseUrl: String
+        get() = prefs.getString("openClawBaseUrl", null) ?: Secrets.openClawBaseUrl
+        set(value) = prefs.edit().putString("openClawBaseUrl", value).apply()
+
+    /** Gateway token for OpenClaw auth. */
+    var openClawToken: String
+        get() = prefs.getString("openClawToken", null) ?: Secrets.openClawToken
+        set(value) = prefs.edit().putString("openClawToken", value).apply()
+
+    /** Session key for agent routing (e.g. "agent:coo:glass" → Wren). */
+    var openClawSessionKey: String
+        get() = prefs.getString("openClawSessionKey", null) ?: Secrets.openClawSessionKey
+        set(value) = prefs.edit().putString("openClawSessionKey", value).apply()
+
+    /** Whether OpenClaw direct mode is configured (URL + token filled in). */
+    val isOpenClawConfigured: Boolean
+        get() = openClawBaseUrl.startsWith("http") &&
+            openClawToken.isNotEmpty() &&
+            !openClawToken.startsWith("YOUR_")
+
     fun resetAll() {
         prefs.edit().clear().apply()
         _captureSourceFlow.value = CaptureSource.PHONE

--- a/samples/CameraAccessAndroid/app/src/main/java/com/meta/wearable/dat/externalsampleapps/cameraaccess/settings/SettingsManager.kt
+++ b/samples/CameraAccessAndroid/app/src/main/java/com/meta/wearable/dat/externalsampleapps/cameraaccess/settings/SettingsManager.kt
@@ -13,7 +13,8 @@ import kotlinx.coroutines.flow.asStateFlow
  */
 enum class IntelligenceEngine(val value: String, val label: String) {
     GEMINI("gemini", "Gemini"),
-    OPENAI("openai", "OpenAI");
+    OPENAI("openai", "OpenAI"),
+    OPENCLAW("openclaw", "OpenClaw");
 
     companion object {
         fun fromValue(value: String?): IntelligenceEngine =

--- a/samples/CameraAccessAndroid/app/src/main/java/com/meta/wearable/dat/externalsampleapps/cameraaccess/ui/LiveKitStreamScreen.kt
+++ b/samples/CameraAccessAndroid/app/src/main/java/com/meta/wearable/dat/externalsampleapps/cameraaccess/ui/LiveKitStreamScreen.kt
@@ -377,6 +377,21 @@ fun LiveKitStreamScreen(
                 onStop = { viewModel.stop() },
             )
         }
+        // Video mute toggle: voice-only mode to save glasses battery.
+        // Only shown during an active call.
+        if (uiState.state is SessionState.Connected) {
+            Row(
+                modifier = Modifier
+                    .align(Alignment.BottomEnd)
+                    .navigationBarsPadding()
+                    .padding(end = 24.dp, bottom = 32.dp),
+            ) {
+                VideoMuteButton(
+                    isMuted = uiState.videoMuted,
+                    onClick = { viewModel.toggleVideoMute() },
+                )
+            }
+        }
     }
 }
 
@@ -725,5 +740,43 @@ private fun FreezeButton(
                 .clip(CircleShape)
                 .background(color),
         )
+    }
+}
+
+/**
+ * Video mute toggle: voice-only mode to save glasses battery.
+ * When muted, the glasses stop streaming video but voice continues.
+ * Camera icon with a slash when muted, plain camera when active.
+ */
+@Composable
+private fun VideoMuteButton(
+    isMuted: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    IconButton(
+        onClick = onClick,
+        modifier = modifier
+            .size(56.dp)
+            .clip(CircleShape)
+            .background(Color.Black.copy(alpha = 0.5f)),
+    ) {
+        if (isMuted) {
+            // Video off: camera with slash
+            Icon(
+                painter = painterResource(id = android.R.drawable.ic_menu_camera),
+                contentDescription = "Video muted — tap to resume",
+                tint = Color.White,
+                modifier = Modifier.size(24.dp),
+            )
+        } else {
+            // Video on: camera
+            Icon(
+                painter = painterResource(id = android.R.drawable.ic_menu_camera),
+                contentDescription = "Video on — tap to mute",
+                tint = AppColor.Yellow,
+                modifier = Modifier.size(24.dp),
+            )
+        }
     }
 }

--- a/samples/CameraAccessAndroid/app/src/main/java/com/meta/wearable/dat/externalsampleapps/cameraaccess/ui/SettingsScreen.kt
+++ b/samples/CameraAccessAndroid/app/src/main/java/com/meta/wearable/dat/externalsampleapps/cameraaccess/ui/SettingsScreen.kt
@@ -50,8 +50,9 @@ import com.meta.wearable.dat.externalsampleapps.cameraaccess.settings.GatewayApi
 import com.meta.wearable.dat.externalsampleapps.cameraaccess.settings.GatewayStatus
 import com.meta.wearable.dat.externalsampleapps.cameraaccess.settings.IntelligenceEngine
 import com.meta.wearable.dat.externalsampleapps.cameraaccess.settings.SettingsManager
+import com.meta.wearable.dat.externalsampleapps.cameraaccess.openclaw.OpenClawAgent
 
-private enum class SettingsSubScreen { CONNECTED_APPS, RECENT_TASKS, GATEWAY }
+private enum class SettingsSubScreen { CONNECTED_APPS, RECENT_TASKS, GATEWAY, OPENCLAW }
 
 @Composable
 fun SettingsScreen(
@@ -64,6 +65,7 @@ fun SettingsScreen(
         SettingsSubScreen.CONNECTED_APPS -> ConnectedAppsScreen(onBack = { subScreen = null })
         SettingsSubScreen.RECENT_TASKS -> RecentTasksScreen(onBack = { subScreen = null })
         SettingsSubScreen.GATEWAY -> GatewaySettingsScreen(onBack = { subScreen = null })
+        SettingsSubScreen.OPENCLAW -> OpenClawSettingsScreen(onBack = { subScreen = null })
         null -> SettingsMainScreen(
             onBack = onBack,
             onOpen = { subScreen = it },
@@ -193,6 +195,10 @@ private fun SettingsMainScreen(
             // surfacing them as primary fields made a configured setup look
             // like one awaiting setup.
             NavigationRow("Gateway settings") { onOpen(SettingsSubScreen.GATEWAY) }
+
+            // OpenClaw direct connection (alternative to hosted gateway)
+            SectionHeader("OpenClaw")
+            NavigationRow("Direct Connection") { onOpen(SettingsSubScreen.OPENCLAW) }
 
             // Reset
             TextButton(onClick = { showResetDialog = true }) {
@@ -355,6 +361,87 @@ private fun GatewaySettingsScreen(
                 placeholder = "wss://your-server.example.com",
                 keyboardType = KeyboardType.Uri,
             )
+
+            Spacer(modifier = Modifier.height(32.dp))
+        }
+    }
+}
+
+/** OpenClaw direct connection: URL, token, and agent picker. */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun OpenClawSettingsScreen(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var openClawBaseUrl by remember { mutableStateOf(SettingsManager.openClawBaseUrl) }
+    var openClawToken by remember { mutableStateOf(SettingsManager.openClawToken) }
+    var openClawSessionKey by remember { mutableStateOf(SettingsManager.openClawSessionKey) }
+    var selectedAgent by remember { mutableStateOf(OpenClawAgent.fromSessionKey(openClawSessionKey)) }
+
+    fun saveAndClose() {
+        SettingsManager.openClawBaseUrl = openClawBaseUrl.trim()
+        SettingsManager.openClawToken = openClawToken.trim()
+        SettingsManager.openClawSessionKey = selectedAgent.sessionKey
+        onBack()
+    }
+
+    BackHandler { saveAndClose() }
+
+    Column(modifier = modifier.fillMaxSize()) {
+        TopAppBar(
+            title = { Text("OpenClaw Connection") },
+            navigationIcon = {
+                IconButton(onClick = { saveAndClose() }) {
+                    Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                }
+            },
+        )
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 16.dp)
+                .navigationBarsPadding(),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            SectionHeader("Gateway")
+            MonoTextField(
+                value = openClawBaseUrl,
+                onValueChange = { openClawBaseUrl = it },
+                label = "OpenClaw URL",
+                placeholder = "https://openclaw.wembassy.com",
+                keyboardType = KeyboardType.Uri,
+            )
+            MonoTextField(
+                value = openClawToken,
+                onValueChange = { openClawToken = it },
+                label = "Gateway Token",
+                placeholder = "Your OpenClaw gateway token",
+            )
+
+            SectionHeader("Agent")
+            FooterText("Routes messages to a specific Wembassy agent.")
+            OpenClawAgent.entries.forEach { agent ->
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable { selectedAgent = agent }
+                        .padding(vertical = 8.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = agent.displayName,
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = if (selectedAgent == agent) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface,
+                    )
+                    if (selectedAgent == agent) {
+                        Text("✓", color = MaterialTheme.colorScheme.primary)
+                    }
+                }
+            }
 
             Spacer(modifier = Modifier.height(32.dp))
         }


### PR DESCRIPTION
## What

Restores the OpenClaw direct connection and adds a full **OpenClaw voice engine** so you can talk to Wembassy agents (Spock, Wren, Mason, Grayson) through LiveKit with your voice.

### 1. OpenClaw Voice Engine (LiveKit pass-through)

Add `openclaw` as a third engine option alongside Gemini Live and OpenAI Realtime. In this mode, LiveKit is just the audio/video transport:

```
User speaks → Google STT → OpenClaw /v1/chat/completions → Google TTS → spoken reply
```

The OpenClaw agent handles the conversation directly. Tool calls (execute, browse, notes) still proxy through the VisionClaw gateway.

**Agent routing:** The `x-openclaw-session-key` header routes to a specific agent:
- `agent:coo:glass` → Wren (COO)
- `agent:cto:glass` → Spock (CTO)
- `agent:cmo:glass` → Mason (CMO)
- `agent:cro:glass` → Grayson (CRO)

### 2. OpenClaw Text Settings (from first commit)

- Restore `OpenClawBridge.kt` for direct HTTP text chat
- Add OpenClaw settings to SettingsManager (URL, token, session key)
- Add agent picker dropdown in Settings UI
- Update `Secrets.kt.example` with OpenClaw defaults

## Files Changed

| File | Change |
|------|--------|
| `agent/main.py` | `build_llm()` returns `{llm, stt, tts}` dict for openclaw engine using OpenAI LLM plugin with custom `base_url` → OpenClaw gateway |
| `gateway/src/server.ts` | Pass `agentSessionKey` through in LiveKit token metadata |
| `SettingsManager.kt` | Add `OPENCLAW` to `IntelligenceEngine` enum |
| `LiveKitSessionViewModel.kt` | Pass `agentSessionKey` in token request body |
| `openclaw/OpenClawBridge.kt` | Restored text bridge (HTTPS + session key) |
| `openclaw/ToolCallModels.kt` | `OpenClawAgent` enum for agent picker |
| `ui/SettingsScreen.kt` | OpenClaw settings sub-screen with agent picker |
| `Secrets.kt.example` | OpenClaw defaults (`openclaw.wembassy.com`) |
| `agent/.env.example` | Document `OPENCLAW_URL`, `OPENCLAW_TOKEN`, `OPENCLAW_SESSION_KEY` |

## How to Use

1. **Agent worker env** (Fly.io): Set `OPENCLAW_URL`, `OPENCLAW_TOKEN`, `OPENCLAW_SESSION_KEY`
2. **Android app**: Settings → Intelligence Engine → OpenClaw
3. **Agent picker**: Settings → OpenClaw → Agent (Spock/Wren/Mason/Grayson)
4. **Talk**: The app connects via LiveKit, speech goes to OpenClaw, response comes back as voice

## Architecture

```
Phone (mic/camera) → LiveKit room → Agent worker
  ├─ Gemini Live (realtime audio I/O)     [existing]
  ├─ OpenAI Realtime (realtime audio I/O) [existing]
  └─ OpenClaw (STT → chat completions → TTS) [NEW]
       └─ x-openclaw-session-key: agent:coo:glass → Wren
```